### PR TITLE
More flexible RGB parsing

### DIFF
--- a/src/main/java/com/mallowigi/colors/ColorData.kt
+++ b/src/main/java/com/mallowigi/colors/ColorData.kt
@@ -34,39 +34,11 @@ import java.util.*
  * This data class serves as a container for color parsing. Used in the
  * different parsers.
  *
- * @property isPercent
- * @property isFloat
- * @property floatRed
- * @property floatGreen
- * @property floatBlue
- * @property floatHue
- * @property floatSaturation
- * @property floatBrightness
- * @property floatAlpha
- * @property intRed
- * @property intGreen
- * @property intBlue
- * @property intAlpha
- * @property alpha
  * @property startParen
  * @property endParen
  */
 @Suppress("DuplicatedCode")
 class ColorData(
-  var isPercent: Boolean = false,
-  var isFloat: Boolean = false,
-  var floatRed: Float = 0.0f,
-  var floatGreen: Float = 0.0f,
-  var floatBlue: Float = 0.0f,
-  var floatHue: Float = 0.0f,
-  var floatSaturation: Float = 0.0f,
-  var floatBrightness: Float = 0.0f,
-  var floatAlpha: Float = 1.0f,
-  var intRed: Int = 0,
-  var intGreen: Int = 0,
-  var intBlue: Int = 0,
-  var intAlpha: Int = 255,
-  var alpha: Boolean = false,
   var startParen: Int = -1,
   var endParen: Int = -1
 ) {
@@ -77,98 +49,20 @@ class ColorData(
     endParen = text.indexOf(')')
   }
 
-  /** Parse red part of a `Color(r,g,b)` form. */
-  fun parseRed(part: String): Unit = when {
-    part.endsWith("f") -> {
-      isFloat = true
-      floatRed = part.substring(0, part.length - 1).toFloat()
-    }
-
-    part.endsWith("%") -> {
-      isPercent = true
-      intRed = part.substring(0, part.length - 1).toInt()
-    }
-
-    else -> intRed = parseInt(part)
+  /** Parse one component part of a `Color(r,g,b)` form. */
+  fun parseComponent(part: String): Any = when {
+    "true" == part -> true
+    "false" == part -> false
+    part.endsWith("f") -> part.substring(0, part.length - 1).toFloat()
+    part.contains(".") -> part.toFloat()
+    part.endsWith("%") -> part.substring(0, part.length - 1).toInt() / 100.0f
+    else -> parseInt(part)
   }
 
-  /** Parse green part of a `Color(r,g,b)` form. */
-  fun parseGreen(part: String): Unit = when {
-    "true" == part -> alpha = true
-    "false" == part -> alpha = false
-    part.endsWith("f") -> {
-      isFloat = true
-      floatGreen = part.substring(0, part.length - 1).toFloat()
-    }
-
-    part.endsWith("%") -> {
-      isPercent = true
-      intGreen = part.substring(0, part.length - 1).toInt()
-    }
-
-    else -> intGreen = parseInt(part)
-  }
-
-  /** Parse blue part of a `Color(r,g,b)` form. */
-  fun parseBlue(part: String): Unit = when {
-    part.endsWith("f") -> {
-      isFloat = true
-      floatBlue = part.substring(0, part.length - 1).toFloat()
-    }
-
-    part.endsWith("%") -> {
-      isPercent = true
-      intBlue = part.substring(0, part.length - 1).toInt()
-    }
-
-    else -> intBlue = parseInt(part)
-  }
-
-  /** Parse alpha part of a `Color(r,g,b,a)` form. */
-  fun parseAlpha(part: String): Unit = when {
-    part.endsWith("f") || part.contains('.') -> {
-      isFloat = true
-      floatAlpha = part.substring(0, part.length - 1).toFloat()
-    }
-
-    part.endsWith("%") -> {
-      isPercent = true
-      floatAlpha = part.substring(0, part.length - 1).toFloat()
-    }
-
-    else -> intAlpha = parseInt(part)
-  }
-
-  /** Parse hue part of a `Color(h,s,l)` form. */
-  fun parseHue(part: String): Unit = when {
-    part.endsWith("%") -> {
-      isPercent = true
-      floatHue = part.substring(0, part.length - 1).toFloat()
-    }
-
-    else -> floatHue = parseFloat(part)
-  }
-
-
-  /** Parse saturation part of a `Color(h,s,l)` form. */
-  fun parseSaturation(part: String): Unit = when {
-    part.endsWith("%") -> {
-      isPercent = true
-      floatSaturation = part.substring(0, part.length - 1).toFloat()
-    }
-
-    else -> floatSaturation = parseFloat(part)
-  }
-
-
-  /** Parse brightness part of a `Color(h,s,l)` form. */
-  fun parseBrightness(part: String): Unit = when {
-    part.endsWith("%") -> {
-      isPercent = true
-      floatBrightness = part.substring(0, part.length - 1).toFloat()
-    }
-
-    else -> floatBrightness = parseFloat(part)
+  /** Parse single component of a `Color(h,s,l)` form. */
+  fun parseHSLComponent(part: String): Float = when {
+    part.endsWith("%") -> part.substring(0, part.length - 1).toFloat()
+    else -> parseFloat(part)
   }
 
 

--- a/src/main/java/com/mallowigi/search/parsers/ColorCtorParser.kt
+++ b/src/main/java/com/mallowigi/search/parsers/ColorCtorParser.kt
@@ -44,23 +44,21 @@ class ColorCtorParser : ColorParser {
       // tokenize the string into "red,green,blue"
       val tokenizer = StringTokenizer(text.substring(startParen + 1, endParen), ",")
       val params = tokenizer.countTokens()
-
-      // parse red part
-      getNextNumber(tokenizer).also { parseRed(it) }
-      // parse green part
-      if (params >= 2) getNextNumber(tokenizer).also { parseGreen(it) }
-      // parse blue part
-      if (params >= 3) getNextNumber(tokenizer).also { parseBlue(it) }
-      // parse alpha
-      if (params == 4) getNextNumber(tokenizer).also { parseAlpha(it) }
+      if (params < 1 || params > 4) return null
 
       return when {
-        isFloat -> Color(floatRed, floatGreen, floatBlue, floatAlpha)
-        else -> when (params) {
-          1 -> Color(intRed)
-          2 -> Color(intRed, alpha)
-          else -> Color(intRed, intGreen, intBlue, intAlpha)
+        params == 1 -> {// single hex int
+            val hex = parseComponent(getNextNumber(tokenizer)) as Int
+            Color(hex)
         }
+
+        params == 2 -> {// hex int followed with hasAlpha
+        val hex = parseComponent(getNextNumber(tokenizer)) as Int
+          val hasAlpha = parseComponent(getNextNumber(tokenizer)) as Boolean
+          Color(hex, hasAlpha)
+        }
+
+        else -> RGBColorParser().parseRGB(text)
       }
     }
   }

--- a/src/main/java/com/mallowigi/search/parsers/HSLColorParser.kt
+++ b/src/main/java/com/mallowigi/search/parsers/HSLColorParser.kt
@@ -47,13 +47,13 @@ class HSLColorParser : ColorParser {
       val params = tokenizer.countTokens()
       if (params < 3) return null
 
-      getNextNumber(tokenizer).also { parseHue(it) }
-      getNextNumber(tokenizer).also { parseSaturation(it) }
-      getNextNumber(tokenizer).also { parseBrightness(it) }
+      val hue = getNextNumber(tokenizer).let { parseHSLComponent(it) }
+      val sat = getNextNumber(tokenizer).let { parseHSLComponent(it) }
+      val lum = getNextNumber(tokenizer).let { parseHSLComponent(it) }
 
-      if (tokenizer.hasMoreTokens()) getNextNumber(tokenizer).also { parseAlpha(it) }
+      val alpha = if (tokenizer.hasMoreTokens()) getNextNumber(tokenizer).let { parseComponent(it) as Float } else 1f
 
-      return ColorUtils.getHSLa(floatHue.toInt(), floatSaturation.toInt(), floatBrightness.toInt(), floatAlpha)
+      return ColorUtils.getHSLa(hue.toInt(), sat.toInt(), lum.toInt(), alpha)
     }
   }
 

--- a/src/main/java/com/mallowigi/search/parsers/NSColorParser.kt
+++ b/src/main/java/com/mallowigi/search/parsers/NSColorParser.kt
@@ -49,24 +49,18 @@ class NSColorParser : ColorParser {
       // tokenize the string
       val tokenizer = StringTokenizer(text.substring(startParen + 1, endParen), " ")
       val params = tokenizer.countTokens()
-      var next = getNextNumber(tokenizer)
-      // extract the part after the :
-      var param = getNextParam(next)
 
-      // float support: sets floatRed/intRed
-      parseHue(param)
-
-      if (params >= 2) {
-        next = getNextNumber(tokenizer)
-        param = getNextParam(next)
-        parseSaturation(param)
+      if (params < 1 || params > 4) return null
+      val components = (1..params).map {
+        val next = getNextNumber(tokenizer)
+        // extract the part after the :
+        val param = getNextParam(next)
+        parseHSLComponent(param)
       }
 
-      if (params >= 3) {
-        next = getNextNumber(tokenizer)
-        param = getNextParam(next)
-        parseBrightness(param)
-      }
+      val hue = components[0]
+      val sat = components.getOrNull(1) ?: 0f
+      val bri = components.getOrNull(2) ?: 0f
 
 //      if (params == 4) {
 //        next = getNextNumber(tokenizer)
@@ -74,7 +68,7 @@ class NSColorParser : ColorParser {
 //        parseAlpha(param)
 //      }
 
-      return Color.getHSBColor(floatHue, floatSaturation, floatBrightness)
+      return Color.getHSBColor(hue, sat, bri)
     }
   }
 

--- a/src/main/java/com/mallowigi/search/parsers/NetColorParser.kt
+++ b/src/main/java/com/mallowigi/search/parsers/NetColorParser.kt
@@ -38,26 +38,7 @@ class NetColorParser : ColorParser {
     val colorData = ColorData()
     colorData.run {
       init(text)
-
-      if (startParen == -1 || endParen == -1) return null
-
-      // tokenize the string into "alpha,red,green,blue"
-      val tokenizer = StringTokenizer(text.substring(startParen + 1, endParen), ",")
-      val params = tokenizer.countTokens()
-
-      getNextNumber(tokenizer).also { parseAlpha(it) }
-      if (params >= 2) getNextNumber(tokenizer).also { parseRed(it) }
-      if (params >= 3) getNextNumber(tokenizer).also { parseGreen(it) }
-      if (params == 4) getNextNumber(tokenizer).also { parseBlue(it) }
-
-      return when {
-        isFloat -> Color(floatRed, floatGreen, floatBlue, floatAlpha)
-        else -> when (params) {
-          1 -> Color(intRed)
-          2 -> Color(intRed, alpha)
-          else -> Color(intRed, intGreen, intBlue, intAlpha)
-        }
-      }
+      return RGBColorParser().parseRGB(text)
     }
   }
 

--- a/src/main/java/com/mallowigi/utils/ColorUtils.kt
+++ b/src/main/java/com/mallowigi/utils/ColorUtils.kt
@@ -64,12 +64,9 @@ object ColorUtils {
 
   /** Parse a color from r,g,b,a in decimal format. */
   fun getDecimalRGBa(r: Int, g: Int, b: Int, a: Float): Color {
-    var red = r
-    var green = g
-    var blue = b
-    red = normalizeDecimal(red)
-    green = normalizeDecimal(green)
-    blue = normalizeDecimal(blue)
+    val red = normalizeDecimal(r)
+    val green = normalizeDecimal(g)
+    val blue = normalizeDecimal(b)
 
     val alpha = toDecimal(normalizeFraction(a))
     return Color(red, green, blue, alpha)
@@ -83,15 +80,10 @@ object ColorUtils {
 
   /** Parse a color from h,s,l,a in decimal format. */
   fun getHSLa(h: Int, s: Int, l: Int, a: Float): Color {
-    var hue = h
-    var saturation = s
-    var lightning = l
-    var alpha = a
-
-    hue = normalizeDegrees(hue)
-    saturation = normalizePercent(saturation)
-    lightning = normalizePercent(lightning)
-    alpha = normalizeFraction(alpha)
+    val hue = normalizeDegrees(h)
+    val saturation = normalizePercent(s)
+    val lightning = normalizePercent(l)
+    val alpha = normalizeFraction(a)
 
     val rgb = convertHSLToRGB(hue / 359.0f, saturation / 100.0f, lightning / 100.0f)
     return Color(rgb[0], rgb[1], rgb[2], alpha)
@@ -107,18 +99,23 @@ object ColorUtils {
 
   /** Parse a color from r,g,b,a in percent format. */
   fun getPercentRGBa(r: Int, g: Int, b: Int, a: Float): Color {
-    var red = r
-    var green = g
-    var blue = b
-    var alpha = a
-    red = normalizePercent(red)
-    green = normalizePercent(green)
-    blue = normalizePercent(blue)
-    alpha = normalizeFraction(alpha)
+    val red = normalizePercent(r)
+    val green = normalizePercent(g)
+    val blue = normalizePercent(b)
+    val alpha = normalizeFraction(a)
 
     return Color(red / 100.0f, green / 100.0f, blue / 100.0f, alpha)
   }
 
+  /** Parse a color from r,g,b,a in float format. */
+  fun getFloatRGBa(r: Float, g: Float, b: Float, a: Float): Color {
+    val red = normalizeFraction(r)
+    val green = normalizeFraction(g)
+    val blue = normalizeFraction(b)
+    val alpha = normalizeFraction(a)
+
+    return Color(red, green, blue, alpha)
+  }
   /** Parse rgb in the hex format #123456. */
   fun getRGB(hex: String): Color {
     val rgb = normalizeRGB(hex, 6)


### PR DESCRIPTION
#### Description

#### Motivation and Context

~~Currently sources with unexpected or wrong values in Color constructors cause the plugin to throw. This is not nice, even wrong sources should be handled gracefully.~~ This does not happen - parsing is always wrapped with `try` at the top level.

 Instead this PR makes parsing more robust against various combinations of int, float and double parameters. This is most likely not relevant for Java or Kotlin, where Int is not convertible to Float, but can be useful in other languages (Scala) and should make the RGB parser more universal and reusable.

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-Functional Change (non-user facing changes)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm here to help! -->
- [ ] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [ ] I updated the version.
- [ ] I updated the changelog with the new functionality.
